### PR TITLE
[#813] Retrieve full tweet when using extended mode for non-retweet

### DIFF
--- a/lib/twitter/tweet.rb
+++ b/lib/twitter/tweet.rb
@@ -32,12 +32,12 @@ module Twitter
     # @note May be > 140 characters.
     # @return [String]
     def full_text
+      tweet_full_text = text.nil? ? attrs[:full_text] : text
       if retweet?
-        tweet_full_text = text.nil? ? attrs[:full_text] : text
         prefix = tweet_full_text[/\A(RT @[a-z0-9_]{1,20}: )/i, 1]
         [prefix, retweeted_status.text].compact.join
       else
-        text
+        tweet_full_text
       end
     end
     memoize :full_text


### PR DESCRIPTION
We're experiencing the same issue listed here:

https://github.com/sferik/twitter/issues/813

But when reviewing the code I noticed that the fix was only made for retweets which means regular tweets still experienced the initial issue.

```
> client.status('842162577459224577', tweet_mode: 'extended').full_text
=> <null>
```

Have made a small adjustment so both retweets and tweets should work with `tweet_mode: 'extended'` now